### PR TITLE
Backfill missing lab metadata (4 files)

### DIFF
--- a/Instructions/Labs/LAB_Ex00_Lab_Setup.md
+++ b/Instructions/Labs/LAB_Ex00_Lab_Setup.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    task: 'Prepare your environment for administration'
-    exercise: 'Exercise 0 - Prepare your environment for administration'
+  task: Prepare your environment for administration
+  exercise: Exercise 0 - Prepare your environment for administration
+  title: 'Lab Setup: Preparing Your Environment for Administration'
+  description: If you are being provided with a tenant as a part of an instructor-led
+    training delivery, please note that the tenant is made available for the purpose
+    of supporting the hands-on labs in the instructor-led training.
+  duration: 54 minutes
+  level: 200
+  islab: true
 ---
 
 ## WWL Tenants - Terms of use

--- a/Instructions/Labs/LAB_Ex01_Sensitive_Information_Types.md
+++ b/Instructions/Labs/LAB_Ex01_Sensitive_Information_Types.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    task: 'Create a custom sensitive information type'
-    exercise: 'Exercise 1 - Create a custom sensitive information type'
+  task: Create a custom sensitive information type
+  exercise: Exercise 1 - Create a custom sensitive information type
+  title: Skilling Task
+  description: Your task is to create and publish sensitivity labels within your organization
+    that classifies and protects sensitive data according to its level of confidentiality
+    and the necessary access controls.
+  duration: 48 minutes
+  level: 100
+  islab: true
 ---
 
 # Skilling Task

--- a/Instructions/Labs/LAB_Ex02_Sensitivity_Labels.md
+++ b/Instructions/Labs/LAB_Ex02_Sensitivity_Labels.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    task: 'Create and publish a sensitivity label'
-    exercise: 'Exercise 2 - Create and publish a sensitivity label'
+  task: Create and publish a sensitivity label
+  exercise: Exercise 2 - Create and publish a sensitivity label
+  title: Skilling Tasks
+  description: Your task is to create and publish sensitivity labels within your organization
+    that classify and protect sensitive data according to its level of confidentiality
+    and the necessary access controls.
+  duration: 148 minutes
+  level: 200
+  islab: true
 ---
 
 # Skilling Tasks

--- a/Instructions/Labs/LAB_Ex03_DLP_policies.md
+++ b/Instructions/Labs/LAB_Ex03_DLP_policies.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    task: 'Create a data loss prevention (DLP) policy'
-    exercise: 'Exercise 3 - Create a data loss prevention (DLP) policy'
+  task: Create a data loss prevention (DLP) policy
+  exercise: Exercise 3 - Create a data loss prevention (DLP) policy
+  title: Skilling Tasks
+  description: '**Tasks**:'
+  duration: 134 minutes
+  level: 100
+  islab: true
 ---
 
 # Skilling Tasks


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 4

- `Instructions/Labs/LAB_Ex00_Lab_Setup.md` (title,description,duration,level,islab)
- `Instructions/Labs/LAB_Ex01_Sensitive_Information_Types.md` (title,description,duration,level,islab)
- `Instructions/Labs/LAB_Ex02_Sensitivity_Labels.md` (title,description,duration,level,islab)
- `Instructions/Labs/LAB_Ex03_DLP_policies.md` (title,description,duration,level,islab)
