### PR TITLE
Backfill missing lab metadata (3 files)

### DIFF
--- a/Instructions/Labs/LAB_Ex01_Sensitive_Information_Types.md
+++ b/Instructions/Labs/LAB_Ex01_Sensitive_Information_Types.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    task: 'Create a custom sensitive information type'
-    exercise: 'Exercise 1 - Create a custom sensitive information type'
+  task: Create a custom sensitive information type
+  exercise: Exercise 1 - Create a custom sensitive information type
+  title: Skilling Task
+  description: In this task, you'll create a new custom sensitive information type that recognizes the pattern of employee IDs near the keywords "Employee" and "ID".
+  duration: 48 minutes
+  level: 100
+  islab: true
 ---
 
 # Skilling Task

--- a/Instructions/Labs/LAB_Ex02_Sensitivity_Labels.md
+++ b/Instructions/Labs/LAB_Ex02_Sensitivity_Labels.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    task: 'Create and publish a sensitivity label'
-    exercise: 'Exercise 2 - Create and publish a sensitivity label'
+  task: Create and publish a sensitivity label
+  exercise: Exercise 2 - Create and publish a sensitivity label
+  title: Skilling Tasks
+  description: You've created a label group for internal use. This group helps you manage related labels for specific departments or data categories.
+  duration: 148 minutes
+  level: 200
+  islab: true
 ---
 
 # Skilling Tasks

--- a/Instructions/Labs/LAB_Ex03_DLP_policies.md
+++ b/Instructions/Labs/LAB_Ex03_DLP_policies.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    task: 'Create a data loss prevention (DLP) policy'
-    exercise: 'Exercise 3 - Create a data loss prevention (DLP) policy'
+  task: Create a data loss prevention (DLP) policy
+  exercise: Exercise 3 - Create a data loss prevention (DLP) policy
+  title: Skilling Tasks
+  description: In this exercise, you'll create a data loss prevention (DLP) policy to protect sensitive data from being shared by users. The DLP policy that you create will inform your users if they want to share content that contains credit card information and allow them to provide a justification for sending this information. The policy will be implemented in simulation mode because you don't want the block action to affect your users yet.
+  duration: 134 minutes
+  level: 100
+  islab: true
 ---
 
 # Skilling Tasks


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 3

- `Instructions/Labs/LAB_Ex01_Sensitive_Information_Types.md` (title,description,duration,level,islab)
- `Instructions/Labs/LAB_Ex02_Sensitivity_Labels.md` (title,description,duration,level,islab)
- `Instructions/Labs/LAB_Ex03_DLP_policies.md` (title,description,duration,level,islab)
